### PR TITLE
Add publish workflow for pypi.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,8 @@ name: Publish packages
 
 on:
   push:
-    tags: ["*"]
+    tags:
+      - "v*.*.*"
 
 permissions:
   contents: write
@@ -15,9 +16,16 @@ jobs:
     with:
       generate: true
       attestations: true
-  pypi:
-    uses: tree-sitter/workflows/.github/workflows/package-pypi.yml@main
-    secrets:
-      PYPI_API_TOKEN: ${{secrets.PYPI_API_TOKEN}}
+  npm:
+    uses: tree-sitter/workflows/.github/workflows/package-npm.yml@main
     with:
       generate: true
+  crates:
+    uses: tree-sitter/workflows/.github/workflows/package-crates.yml@main
+    with:
+      generate: true
+  pypi:
+    uses: tree-sitter/workflows/.github/workflows/package-pypi.yml@main
+    with:
+      generate: true
+

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tree-sitter-clingo",
+  "name": "@potassco/tree-sitter-clingo",
   "version": "1.0.0",
   "description": "Clingo grammar for tree-sitter",
   "repository": {


### PR DESCRIPTION
I would like to get the tree-sitter grammar published to pypi, so folks can access it using the python API of tree-sitter.