### PR TITLE
Add tests for doc comment syntax highlighting.

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -69,22 +69,6 @@
  (doc_comment)
 ] @comment
 
-;;
-;; doc comments
-;;
-;; We use raw for variables with elevated priority here because this nicely
-;; aligns with raw tags.
-;;
-(doc_predicate (identifier) @function)
-(doc_predicate (variables (variable) @markup.raw (#set! "priority" 200)))
-(doc_fragment_code) @markup.raw
-(doc_fragment_bold) @markup.strong
-[(doc_fragment_emph) (doc_fragment_italic)] @markup.italic
-(doc_args ("Args:") @markup.heading)
-(doc_arg 
-  ("-") @punctuation.delimiter (#set! "priority" 200)
-  (variable) @markup.raw (#set! "priority" 200)
-  (":") @punctuation.delimiter (#set! "priority" 200))
 
 ;;
 ;; punctuation
@@ -312,3 +296,20 @@
   (identifier) @module)
 (program
   name: (identifier) @module)
+
+;;
+;; doc comments
+;;
+;; We use raw for variables with elevated priority here because this nicely
+;; aligns with raw tags.
+;;
+(doc_predicate (identifier) @function)
+(doc_predicate (variables (variable) @markup.raw (#set! "priority" 200)))
+(doc_fragment_code) @markup.raw
+(doc_fragment_bold) @markup.strong
+[(doc_fragment_emph) (doc_fragment_italic)] @markup.italic
+(doc_args ("Args:") @markup.heading)
+(doc_arg 
+  ("-") @punctuation.delimiter (#set! "priority" 200)
+  (variable) @markup.raw (#set! "priority" 200)
+  (":") @punctuation.delimiter (#set! "priority" 200))

--- a/test/highlight/test_highlights.lp
+++ b/test/highlight/test_highlights.lp
@@ -223,3 +223,40 @@ p(~1, -1, |1|)
 %                       ^ operator
 %                               ^ operator
 %                                       ^ operator
+
+% this is a comment
+%   ^ comment
+
+%*
+this is a block comment 
+*%
+%       ^ comment
+
+%*! some_predicate (A, B ,C ) *%
+%    ^ function
+%                   ^ markup.raw
+
+%*! some_predicate (A, B ,C )
+Here is `some` documentation for the *predicate*.
+*%
+% ^ comment
+%         ^ markup.raw
+%                   ^ comment
+%                                        ^ markup.italic
+
+%*! some_predicate (A, B ,C )
+Maybe a *longer* one
+over _multiple_ lines 
+*%
+% ^ comment
+%        ^ markup.italic
+%                ^ comment
+
+%*! some_predicate (A, B ,C )
+Args:
+- A: **some** description for *A* *%
+% <- punctuation.delimiter
+% ^ markup.raw
+%  ^ punctuation.delimiter
+%       ^ markup.strong
+%                              ^ markup.italic


### PR DESCRIPTION
Add tests for doc comment syntax highlighting.
We need to put the highlight queries for doc comments at the end of file, as the `#set! "priority"` directives are a nvim specific thing, not supported by the tree-sitter highlight testing mechanism.